### PR TITLE
 Solve TypeError in django 1.11 and python3

### DIFF
--- a/imagecompressor/management/commands/compressimages.py
+++ b/imagecompressor/management/commands/compressimages.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
             pass
         images_directory.mkdir()
 
-        with open(staticfiles_manifest_path) as staticfiles_manifest:
+        with staticfiles_manifest_path.open() as staticfiles_manifest:
             manifest = json.load(staticfiles_manifest)
             for file_key in manifest.get('paths', {}):
                 file_path = Path(file_key)
@@ -65,7 +65,7 @@ class Command(BaseCommand):
 
                         manifest['paths'][file_key] = str(relative_new_image_path)
 
-        with open(staticfiles_manifest_path, 'w') as staticfiles_manifest:
+        with staticfiles_manifest_path.open('w') as staticfiles_manifest:
             json.dump(manifest, staticfiles_manifest)
 
 


### PR DESCRIPTION
Django uses pathlib to store paths https://docs.python.org/3/library/pathlib.html
They provide an object oriented path manipulation (you do path.open() instead of open(path). 

This solves the problem without regression I think (if the path is already a string nothing will change, if it's a pathlib path, it will be casted to it's string value).